### PR TITLE
feat(enrichment): ER-1421 fix login reset error message

### DIFF
--- a/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
@@ -31,6 +31,7 @@
                                    type="text" autofocus autocomplete="username" placeholder="Nutzername oder E-Mail"
                                    class="input input-bordered input-sm <#if messagesPerField.existsError('username','password')>border-primary</#if>"
                                    aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
+                                   aria-describedby="<#if messagesPerField.existsError('username')>username-empty</#if>"
                             />
                             <span class="absolute right-0 bottom-0.5">
                                 <#if messagesPerField.existsError('username')>
@@ -42,6 +43,13 @@
                                 </#if>
                             </span>
                         </label>
+                        <#if messagesPerField.existsError('username')>
+                            <div id="username-empty" class="label flex justify-between">
+                                <span class="text-error label-text-alt">
+                                    Hinweis: Bitte geben Sie einen Nutzernamen an
+                                </span>
+                            </div>
+                        </#if>
 
                         <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
                             <button tabindex="6" name="login" id="kc-login" type="submit" class="btn btn-block my-4">

--- a/variants/enrichment/files/themes/enrichment/login/resources/css/styles.css
+++ b/variants/enrichment/files/themes/enrichment/login/resources/css/styles.css
@@ -124,6 +124,10 @@ body {
     color: var(--color-neutral-content);
 }
 
+.text-error {
+    color: var(--color-primary);
+}
+
 .grid {
     display: grid;
 }


### PR DESCRIPTION
# Description

## Links to Tickets or other PRs

- https://jira.dataport.de/browse/ER-1421

## Notes

- Added inline validation error message on the password-reset page (`login-reset-password.ftl`): when the username field is submitted empty, a hint is shown below the field ("Hinweis: Bitte geben Sie einen Nutzernamen an")
- Added `aria-describedby` attribute to the username input pointing to the error element (`username-empty`) so screen readers announce the error message — improves accessibility
- Added `.text-error` CSS utility class in the Keycloak theme stylesheet, mapping to `var(--color-primary)` to align error text color with the theme's design tokens
- Changes are limited to the custom Keycloak `enrichment` login theme; no backend or application logic affected
- Rollout: redeploying the Keycloak theme (e.g. via `redeployKeycloak`) is sufficient; no database migrations or config changes required

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.