### PR TITLE
fix(enrichment): ER-1395 heading tags in keycloak templates

### DIFF
--- a/variants/enrichment/files/themes/enrichment/email/html/executeActions.ftl
+++ b/variants/enrichment/files/themes/enrichment/email/html/executeActions.ftl
@@ -6,6 +6,7 @@
 <@layout.emailLayout>
 
     <#if requiredActionsText == "Passwort aktualisieren">
+        <h1>Willkommen beim Enrichment-Programm</h1>
         <p>Für Sie wurde ein Benutzerkonto im Enrichment-Programm angelegt.</p>
         <p>Ihr Nutzername lautet: <b>${user.getUsername()}</b></p>
         <p>Klicken Sie auf den unten stehenden Link, um das Passwort für Ihr Benutzerkonto zu setzen.</p>

--- a/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
@@ -17,7 +17,7 @@
             <div id="kc-form-wrapper" class="w-full md:w-[500px] bg-base-light rounded-base mt-8">
                 <div class="p-16">
 
-                    <h2 class="text-center mt-0">Passwort zurücksetzen</h2>
+                    <h1 class="text-center mt-0">Passwort zurücksetzen</h1>
                     <p>Um Ihr Passwort zurückzusetzen, geben Sie bitte Ihren Nutzernamen oder Ihre E-Mail-Adresse an.</p>
                     <p>Ein Link zum Zurücksetzen Ihres Passworts wird an die hinterlegte E-Mail-Adresse versendet.</p>
                     <form id="kc-reset-password-form" class="${properties.kcFormClass!}" action="${url.loginAction}"

--- a/variants/enrichment/files/themes/enrichment/login/login-update-password.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login-update-password.ftl
@@ -17,7 +17,7 @@
             <div id="kc-form-wrapper" class="w-full md:w-[500px] bg-base-light rounded-base mt-8">
                 <div class="p-16">
 
-                    <h2 class="text-center mt-0">Neues Passwort setzen</h2>
+                    <h1 class="text-center mt-0">Neues Passwort setzen</h1>
                     <p>Bitte vergeben Sie ein neues sicheres Passwort gemäß der Passwort-Policy.</p>
 
                     <div class="pl-8 text-[14px] pb-4">

--- a/variants/enrichment/files/themes/enrichment/login/login.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login.ftl
@@ -17,7 +17,7 @@
             <div id="kc-form-wrapper" class="w-full md:w-[500px] bg-base-light rounded-base mt-8">
                 <div class="p-16">
 
-                    <h2 class="text-center mt-0">Anmeldung</h2>
+                    <h1 class="text-center mt-0">Anmeldung</h1>
 
                     <form id="kc-form-login" onsubmit="login.disabled = true; return true;"
                           action="${url.loginAction}" method="post">


### PR DESCRIPTION
# Description

## Links to Tickets or other PRs

- https://jira.dataport.de/browse/ER-1395

## Notes

- Changed all page/section heading tags in the custom Keycloak theme from `<h2>` to `<h1>` for accessibility compliance.
- Affected templates:
  - `login/login.ftl` – login page heading "Anmeldung"
  - `login/login-reset-password.ftl` – password reset page heading "Passwort zurücksetzen"
  - `login/login-update-password.ftl` – set new password page heading "Neues Passwort setzen"
  - `email/html/executeActions.ftl` – account creation email heading "Willkommen beim Enrichment-Programm"
- Each page/email had exactly one top-level heading; using `<h2>` violated the WCAG requirement that each document has exactly one `<h1>` as its primary heading.
- No visual changes are expected since the existing CSS styles the heading identically; this is a purely semantic/accessibility fix.

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.