### PR TITLE
fix(enrichment): ER-1395 fix tab indices in login templates

### DIFF
--- a/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
@@ -4,12 +4,11 @@
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
         <div id="kc-form" class="flex flex-col justify-center items-center h-full px-4 md:px-0">
-            <a href="${client.baseUrl}" class="cursor-pointer">
+            <a href="${client.baseUrl}" class="cursor-pointer" tabindex="1">
                 <img
                     src="${url.resourcesPath}/img/logo.svg"
                     width="88"
                     height="82"
-                    tabindex="1"
                     alt="enrichment-logo"
                     draggable="false"
                     class="h-[41px] w-[44px] mt-8">
@@ -44,7 +43,7 @@
                         </label>
 
                         <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-                            <button tabindex="6" name="login" id="kc-login" type="submit" class="btn btn-block my-4">
+                            <button tabindex="3" name="login" id="kc-login" type="submit" class="btn btn-block my-4">
                                 Passwort zurücksetzen
                                 <svg class="inline-block" height="20" width="20" fill="#ffffff">
                                     <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward"
@@ -53,7 +52,7 @@
                             </button>
                             <div id="kc-form-options" class="${properties.kcFormOptionsClass!} w-full flex justify-center">
                                 <div class="${properties.kcFormOptionsWrapperClass!}">
-                                    <span class="text-12">Kennen Sie Ihr Passwort? <a href="${url.loginUrl}">zurück zur Anmeldung</a></span>
+                                    <span class="text-12">Kennen Sie Ihr Passwort? <a href="${url.loginUrl}" tabindex="4">zurück zur Anmeldung</a></span>
                                 </div>
                             </div>
                         </div>
@@ -61,7 +60,7 @@
                 </div>
             </div>
             <div class="text-center mt-2">
-                <a href="${client.baseUrl}" tabindex="7" class="link cursor-pointer">zurück zur Startseite</a>
+                <a href="${client.baseUrl}" tabindex="5" class="link cursor-pointer">zurück zur Startseite</a>
             </div>
         </div>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>

--- a/variants/enrichment/files/themes/enrichment/login/login-update-password.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login-update-password.ftl
@@ -4,12 +4,11 @@
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
         <div id="kc-form" class="flex flex-col justify-center items-center h-full px-4 md:px-0">
-            <a href="${client.baseUrl}" class="cursor-pointer">
+            <a href="${client.baseUrl}" class="cursor-pointer" tabindex="1">
                 <img
                     src="${url.resourcesPath}/img/logo.svg"
                     width="88"
                     height="82"
-                    tabindex="1"
                     alt="enrichment-logo"
                     draggable="false"
                     class="h-[41px] w-[44px] mt-8">
@@ -80,7 +79,7 @@
                             <span class="absolute right-0 bottom-0.5">
                                 <span class="cursor-pointer"
                                       aria-label="${msg("showPassword")}"
-                                      aria-controls="password-new" data-password-toggle tabindex="4"
+                                      aria-controls="password-new" data-password-toggle tabindex="3"
                                       data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}"
                                       data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}">
                                     <svg class="inline-block mr-2" height="20" width="20">
@@ -103,7 +102,7 @@
                             <span class="label">
                                 <span class="label-text">Neues Passwort wiederholen</span>
                             </span>
-                            <input tabindex="2" id="password-confirm" name="password-confirm"
+                            <input tabindex="4" id="password-confirm" name="password-confirm"
                                    type="password" autofocus autocomplete="new-password" placeholder="Passwort"
                                    class="input input-bordered input-sm <#if messagesPerField.existsError('password')>border-primary</#if>"
                                    aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"
@@ -111,7 +110,7 @@
                             <span class="absolute right-0 bottom-0.5">
                                 <span class="cursor-pointer"
                                       aria-label="${msg("showPassword")}"
-                                      aria-controls="password-confirm" data-password-toggle tabindex="4"
+                                      aria-controls="password-confirm" data-password-toggle tabindex="5"
                                       data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}"
                                       data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}">
                                     <svg class="inline-block mr-2" height="20" width="20">

--- a/variants/enrichment/files/themes/enrichment/login/login.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login.ftl
@@ -4,12 +4,11 @@
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
         <div id="kc-form" class="flex flex-col justify-center items-center h-full px-4 md:px-0">
-            <a href="${client.baseUrl}" class="cursor-pointer">
+            <a href="${client.baseUrl}" class="cursor-pointer" tabindex="1">
                 <img
                     src="${url.resourcesPath}/img/logo.svg"
                     width="88"
                     height="82"
-                    tabindex="1"
                     alt="enrichment-logo"
                     draggable="false"
                     class="h-[41px] w-[44px] mt-8">


### PR DESCRIPTION
# Description

## Links to Tickets or other PRs

https://jira.dataport.de/browse/ER-1395

## Notes

- Moved `tabindex` from `<img>` elements to their parent `<a>` wrapper across all three login templates (`login.ftl`, `login-reset-password.ftl`, `login-update-password.ftl`). `<img>` is not a focusable/interactive element, so placing `tabindex` on it had no effect; the fix ensures keyboard navigation correctly focuses the logo link.
- Corrected and compacted `tabindex` values in `login-reset-password.ftl`: submit button changed from `6` → `3`, back-to-login link assigned `4`, back-to-start link changed from `7` → `5`. Removes gaps in the tab order sequence.
- Fixed duplicate `tabindex="4"` on both password-toggle buttons in `login-update-password.ftl`. They are now assigned unique sequential values (`3` and `5`), with the password-confirm input adjusted to `4` to maintain logical focus order: logo (1) → new password (2) → new password toggle (3) → confirm password (4) → confirm password toggle (5).

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.