### PR TITLE
feat: ER-1612 use kern ux for links - keycloak changes

### DIFF
--- a/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login-reset-password.ftl
@@ -6,12 +6,12 @@
         <div id="kc-form" class="flex flex-col justify-center items-center h-full px-4 md:px-0">
             <a href="${client.baseUrl}" class="cursor-pointer" tabindex="1">
                 <img
-                    src="${url.resourcesPath}/img/logo.svg"
-                    width="88"
-                    height="82"
-                    alt="Enrichment - Zur Startseite"
-                    draggable="false"
-                    class="h-[41px] w-[44px] mt-8">
+                        src="${url.resourcesPath}/img/logo.svg"
+                        width="88"
+                        height="82"
+                        alt="Enrichment - Zur Startseite"
+                        draggable="false"
+                        class="h-[41px] w-[44px] mt-8">
             </a>
             <div id="kc-form-wrapper" class="w-full md:w-[500px] bg-base-light rounded-base mt-8">
                 <div class="p-16">
@@ -36,8 +36,8 @@
                                 <#if messagesPerField.existsError('username')>
                                     <svg class="inline-block fill-primary mr-2" height="20" width="20">
                                         <use
-                                            href="${url.resourcesPath}/icons/alert-circle-outline.svg#alert-circle-outline"
-                                            width="20" height="20"></use>
+                                                href="${url.resourcesPath}/icons/alert-circle-outline.svg#alert-circle-outline"
+                                                width="20" height="20"></use>
                                     </svg>
                                 </#if>
                             </span>
@@ -49,18 +49,18 @@
                                 </span>
                             </div>
                         </#if>
-
                         <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
                             <button tabindex="3" name="login" id="kc-login" type="submit" class="btn btn-block my-4">
                                 Passwort zurücksetzen
-                                <svg class="inline-block" height="20" width="20" fill="#ffffff">
-                                    <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward"
-                                         width="20" height="20"></use>
-                                </svg>
                             </button>
                             <div id="kc-form-options" class="${properties.kcFormOptionsClass!} w-full flex justify-center">
                                 <div class="${properties.kcFormOptionsWrapperClass!}">
-                                    <span class="text-12">Kennen Sie Ihr Passwort? <a href="${url.loginUrl}" tabindex="4">zurück zur Anmeldung</a></span>
+                                    <span class="text-12">Kennen Sie Ihr Passwort?<a href="${url.loginUrl}" tabindex="4" class="link link-sm inline-flex items-center gap-[2px] ml-[6px] text-info">
+                                        <svg class="inline-block fill-current" height="14" width="14" aria-hidden="true" focusable="false">
+                                            <use href="${url.resourcesPath}/icons/keyboard-backspace.svg#keyboard-backspace" width="14" height="14"></use>
+                                        </svg>
+                                        zurück zur Anmeldung
+                                    </a></span>
                                 </div>
                             </div>
                         </div>
@@ -68,7 +68,12 @@
                 </div>
             </div>
             <div class="text-center mt-2">
-                <a href="${client.baseUrl}" tabindex="5" class="link cursor-pointer">zurück zur Startseite</a>
+                <a href="${client.baseUrl}" tabindex="5" class="link cursor-pointer inline-flex items-center gap-[4px] text-info">
+                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                        <use href="${url.resourcesPath}/icons/keyboard-backspace.svg#keyboard-backspace" width="16" height="16"></use>
+                    </svg>
+                    zurück zur Startseite
+                </a>
             </div>
         </div>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>

--- a/variants/enrichment/files/themes/enrichment/login/login.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/login.ftl
@@ -4,14 +4,14 @@
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
         <div id="kc-form" class="flex flex-col justify-center items-center h-full px-4 md:px-0">
-            <a href="${client.baseUrl}" class="cursor-pointer" tabindex="1">
+            <a href="${client.baseUrl}" class="cursor-pointer" tabindex="0" aria-label="Enrichment Logo">
                 <img
-                    src="${url.resourcesPath}/img/logo.svg"
-                    width="88"
-                    height="82"
-                    alt="Enrichment - Zur Startseite"
-                    draggable="false"
-                    class="h-[41px] w-[44px] mt-8">
+                        src="${url.resourcesPath}/img/logo.svg"
+                        width="88"
+                        height="82"
+                        aria-hidden="true"
+                        draggable="false"
+                        class="h-[41px] w-[44px] mt-8">
             </a>
             <div id="kc-form-wrapper" class="w-full md:w-[500px] bg-base-light rounded-base mt-8">
                 <div class="p-16">
@@ -25,12 +25,12 @@
 
                                 <#if message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
                                     <div class="alert alert-${message.type}">
-                                         <#if message.type = 'success'>
-                                             <svg class="inline-block min-w-[20px]" height="20" width="20" fill="#ffffff">
-                                                 <use href="${url.resourcesPath}/icons/check-circle.svg#check-circle"
-                                                      width="20" height="20"></use>
-                                             </svg>
-                                         </#if>
+                                        <#if message.type = 'success'>
+                                            <svg class="inline-block min-w-[20px]" height="20" width="20" fill="#ffffff">
+                                                <use href="${url.resourcesPath}/icons/check-circle.svg#check-circle"
+                                                     width="20" height="20"></use>
+                                            </svg>
+                                        </#if>
                                         <#if message.type = 'error'>
                                             <svg class="inline-block min-w-[20px]" height="20" width="20" fill="#ffffff">
                                                 <use href="${url.resourcesPath}/icons/alert-circle.svg#alert-circle"
@@ -47,17 +47,17 @@
                                     <span class="label">
                                         <span class="label-text">Nutzername eingeben</span>
                                     </span>
-                                    <input tabindex="2" id="username" name="username" value="${(login.username!'')}"
+                                    <input tabindex="0" id="username" name="username" value="${(login.username!'')}"
                                            type="text" autofocus autocomplete="username" placeholder="Nutzername"
                                            class="input input-bordered input-sm <#if messagesPerField.existsError('username','password')>border-primary</#if>"
                                            aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                     />
                                     <span class="absolute right-0 bottom-0.5">
                                         <#if messagesPerField.existsError('username','password')>
-                                            <svg class="inline-block fill-primary mr-2" height="20" width="20">
+                                            <svg class="inline-block fill-primary mr-2" height="20" width="20" aria-hidden="true">
                                                 <use
-                                                    href="${url.resourcesPath}/icons/alert-circle-outline.svg#alert-circle-outline"
-                                                    width="20" height="20"></use>
+                                                        href="${url.resourcesPath}/icons/alert-circle-outline.svg#alert-circle-outline"
+                                                        width="20" height="20"></use>
                                             </svg>
                                         </#if>
                                     </span>
@@ -73,34 +73,41 @@
                                     <span class="label">
                                         <span class="label-text">Passwort eingeben</span>
                                     </span>
-                                    <input tabindex="3" id="password" placeholder="Passwort" name="password"
+                                    <input tabindex="0" id="password" placeholder="Passwort" name="password"
                                            type="password" autocomplete="current-password"
                                            class="input input-bordered input-sm <#if messagesPerField.existsError('username','password')>border-primary</#if>"
                                            aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                                           aria-label="Passwort eingeben"
                                     />
                                     <span class="absolute right-0 bottom-0.5 select-none">
-                                        <span class="cursor-pointer"
-                                              aria-label="${msg("showPassword")}"
-                                              aria-controls="password" data-password-toggle tabindex="4"
-                                              data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}"
-                                              data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}">
-                                            <svg class="inline-block mr-2" height="20" width="20">
+                                        <button type="button"
+                                                class="cursor-pointer inline-flex items-center justify-center bg-white border-none p-0"
+                                                aria-label="${msg("showPassword")}"
+                                                aria-controls="password"
+                                                aria-pressed="false"
+                                                data-password-toggle
+                                                data-label-show="${msg("showPassword")}"
+                                                data-label-hide="${msg("hidePassword")}">
+                                            <svg class="inline-block mr-2" height="20" width="20" aria-hidden="true">
                                                 <use
-                                                    href="${url.resourcesPath}/icons/eye-off-outline.svg#eye-off-outline"
-                                                    width="20" height="20"></use>
+                                                        href="${url.resourcesPath}/icons/eye-off-outline.svg#eye-off-outline"
+                                                        width="20" height="20"></use>
                                             </svg>
-                                        </span>
+                                        </button>
                                         <#if messagesPerField.existsError('username','password')>
-                                            <svg class="inline-block fill-primary mr-2" height="20" width="20" tabindex="4">
+                                            <svg class="inline-block fill-primary mr-2" height="20" width="20" tabindex="0">
                                                 <use
-                                                    href="${url.resourcesPath}/icons/alert-circle-outline.svg#alert-circle-outline"
-                                                    width="20" height="20"></use>
+                                                        href="${url.resourcesPath}/icons/alert-circle-outline.svg#alert-circle-outline"
+                                                        width="20" height="20"></use>
                                             </svg>
                                         </#if>
                                     </span>
                                 </label>
                                 <div class="flex justify-end mt-1">
-                                    <a tabindex="5" href="${url.loginResetCredentialsUrl}" class="link link-sm">
+                                    <a tabindex="0" href="${url.loginResetCredentialsUrl}" class="link link-sm inline-flex items-center gap-[4px] text-info">
+                                        <svg class="inline-block fill-current" height="14" width="14" aria-hidden="true" focusable="false">
+                                            <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward" width="14" height="14"></use>
+                                        </svg>
                                         Passwort vergessen?
                                     </a>
                                 </div>
@@ -118,19 +125,20 @@
                         <div id="kc-form-buttons" class="mt-4">
                             <input type="hidden" id="id-hidden-input" name="credentialId"
                                    <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                            <button tabindex="6" name="login" id="kc-login" type="submit" class="btn btn-block">
+                            <button aria-label="Anmelden" tabindex="0" name="login" id="kc-login" type="submit" class="btn btn-block">
                                 Anmelden
-                                <svg class="inline-block" height="20" width="20" fill="#ffffff">
-                                    <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward"
-                                         width="20" height="20"></use>
-                                </svg>
                             </button>
                         </div>
                     </form>
                 </div>
             </div>
             <div class="text-center mt-2">
-                <a href="${client.baseUrl}" tabindex="7" class="link cursor-pointer">zurück zur Startseite</a>
+                <a href="${client.baseUrl}" tabindex="0" class="link cursor-pointer inline-flex items-center gap-[4px] text-info">
+                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                        <use href="${url.resourcesPath}/icons/keyboard-backspace.svg#keyboard-backspace" width="16" height="16"></use>
+                    </svg>
+                    zurück zur Startseite
+                </a>
             </div>
         </div>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>

--- a/variants/enrichment/files/themes/enrichment/login/template.ftl
+++ b/variants/enrichment/files/themes/enrichment/login/template.ftl
@@ -1,7 +1,7 @@
 <#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false>
     <!DOCTYPE html>
     <html
-        class="${properties.kcHtmlClass!}"<#if realm.internationalizationEnabled> lang="${locale.currentLanguageTag}"</#if>>
+            class="${properties.kcHtmlClass!}"<#if realm.internationalizationEnabled> lang="${locale.currentLanguageTag}"</#if>>
 
     <head>
         <meta charset="utf-8">
@@ -98,31 +98,54 @@
 
                 <div class="w-full h-[354px] md:h-[170px] bg-base-light flex justify-center items-center">
                     <div
-                        class="max-w-footer w-full grid grid-cols-2 ps-2.5 md:px-[93px] footer:px-0 gap-[38px] md:gap-0">
+                            class="max-w-footer w-full grid grid-cols-2 ps-2.5 md:px-[93px] footer:px-0 gap-[38px] md:gap-0">
                         <div class="col-span-2 md:col-span-1 flex flex-col justify-end gap-y-[10px] mt-4 md:mt-0">
                             <div class="flex flex-wrap gap-x-[28px] gap-y-[10px] select-none">
-                                <a href="${client.baseUrl}/faq" class="cursor-pointer footer-item p-[1px]">FAQ</a>
-                                <a href="${client.baseUrl}/contact" class="cursor-pointer footer-item p-[1px]">Kontakt</a>
-                                <div class="cursor-pointer footer-item p-[1px]">Datenschutz</div>
+                                <a href="${client.baseUrl}/faq" class="cursor-pointer footer-item p-[1px] inline-flex items-center gap-[4px] text-info">
+                                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                                        <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward" width="16" height="16"></use>
+                                    </svg>
+                                    FAQ
+                                </a>
+                                <a href="${client.baseUrl}/contact" class="cursor-pointer footer-item p-[1px] inline-flex items-center gap-[4px] text-info">
+                                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                                        <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward" width="16" height="16"></use>
+                                    </svg>
+                                    Kontakt
+                                </a>
+                                <div class="cursor-pointer footer-item p-[1px] inline-flex items-center gap-[4px] text-info">
+                                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                                        <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward" width="16" height="16"></use>
+                                    </svg>
+                                    Datenschutz
+                                </div>
                             </div>
                             <div class="flex flex-wrap gap-x-[28px] gap-y-[10px] select-none">
                                 <a href="${client.baseUrl}/legal/imprint" target="_blank"
-                                   class="cursor-pointer footer-item p-[1px]">
+                                   aria-describedby="footer-external-link-hint"
+                                   class="cursor-pointer footer-item p-[1px] inline-flex items-center gap-[4px] text-info">
+                                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                                        <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward" width="16" height="16"></use>
+                                    </svg>
                                     Impressum
                                 </a>
-                                <div class="cursor-pointer footer-item p-[1px]">Barrierefreiheit</div>
+                                <div class="cursor-pointer footer-item p-[1px] inline-flex items-center gap-[4px] text-info">
+                                    <svg class="inline-block fill-current" height="16" width="16" aria-hidden="true" focusable="false">
+                                        <use href="${url.resourcesPath}/icons/arrow-forward.svg#arrow-forward" width="16" height="16"></use>
+                                    </svg>
+                                    Barrierefreiheit
+                                </div>
+                                <span id="footer-external-link-hint" class="sr-only">Öffnet Link in neuem Tab</span>
                             </div>
                         </div>
                         <div
-                            class="col-span-2 md:col-span-1 flex justify-center items-center md:justify-end mb-4 md:mb-0">
-                            <a href="">
-                                <svg height="114" width="274" aria-hidden="true" focusable="false>
-                                    <use href="${url.resourcesPath}/img/schleswig-holstein.svg#schleswig-holstein"
-                                         class="text-info"
-                                         height="114" width="274">
-                                    </use>
-                                </svg>
-                            </a>
+                                class="col-span-2 md:col-span-1 flex justify-center items-center md:justify-end mb-4 md:mb-0">
+                            <svg height="114" width="274" aria-hidden="true" focusable="false">
+                                <use href="${url.resourcesPath}/img/schleswig-holstein.svg#schleswig-holstein"
+                                     class="text-info"
+                                     height="114" width="274">
+                                </use>
+                            </svg>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
# Description

## Links to Tickets or other PRs

- https://jira.dataport.de/browse/ER-1612
- https://jira.dataport.de/browse/ER-1764

## Notes

Changes to the Keycloak login theme (`template.ftl`, `login.ftl`, `login-reset-password.ftl`) implement the KERN UX guideline for links and the use of arrow icons that should mark *navigational* links, not action buttons:

- *ER-1612 make ux links kern - footer and login page*:
  - `login.ftl`: removed the decorative `arrow-forward` icon from the "Anmelden" submit button; added an `arrow-forward` icon to the forward-navigating "Passwort vergessen?" link; added a `keyboard-backspace` icon to the "zurück zur Startseite" back-navigation link.
  - `login-reset-password.ftl`: removed the decorative `arrow-forward` icon from the "Passwort zurücksetzen" submit button; added a `keyboard-backspace` icon to both the "zurück zur Anmeldung" and "zurück zur Startseite" back-navigation links.
  - `template.ftl`: restyled the footer links (FAQ, Kontakt, Impressum, and the still non-interactive "Datenschutz"/"Barrierefreiheit" placeholders) with an `arrow-forward` icon and consistent `inline-flex items-center gap-[4px] text-info` styling. Added `aria-describedby="footer-external-link-hint"` to the "Impressum" link (opens in a new tab) plus a new `sr-only` span `footer-external-link-hint` ("Öffnet Link in neuem Tab") so screen-reader users are warned before leaving the page.
- *ER-1612 ER-1764 bugfix: add SR info for open-in-new*:
  - `template.ftl`: removed a stray, unmatched `</a>` closing tag left over in the footer near the Schleswig-Holstein emblem SVG, fixing invalid HTML markup. This was part of a broader ER-1764 fix that introduced a reusable `externalLinkHintId` screen-reader-hint pattern for "opens in a new tab" links across the Angular client (e.g. course detail modal, association sponsors carousel) — those client-side changes don't touch the Keycloak theme files.

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.